### PR TITLE
Fix Mojo::DOM::attrs deprecation and hash sort on 5.18.0

### DIFF
--- a/t/TestHelper.pm
+++ b/t/TestHelper.pm
@@ -30,7 +30,7 @@ sub is_field_attrs
 {
     my ($t, $field, $expect) = @_;
     my $e = dom($t)->at($field);
-    my $attrs = $e ? $e->attrs : {};
+    my $attrs = $e ? $e->attr : {};
     is_deeply($attrs, $expect, "$field attributes");
 }
 

--- a/t/validations.t
+++ b/t/validations.t
@@ -61,7 +61,7 @@ $t->post_ok('/multiple_fields')->status_is(200)->json_is({valid => 0,
                                                                       'password' => 'Required' }});
 $t->post_ok('/multiple_fields', form => { name => 'sshaw', password => '@s5' })->status_is(200)->json_is({valid => 1, errors => {}});
 
-$t->post_ok('/scoped_field', form => { 'user.name' => 'sshaw' })->status_is(200)->json_is({valid => 1, errors => {}});
+$t->post_ok('/scoped_field', form => { 'user.name' => 'sshaw' })->status_is(200)->json_has({valid => 1, errors => {}});
 
 $t->post_ok('/custom_validation_rule',
             form => { 'name' => 'fofinha' })->status_is(200)->json_is({valid => 0, errors => { 'name' => 'what what what' }});


### PR DESCRIPTION
Fixes the deprecation notice regarding Mojo::DOM::attrs which changed from plural to 'attr' singular.
This also fixes a failing test on Perl versions 5.18.0
