### PR TITLE
Filters is not applied, and use the "STRUCTURED REQUEST PARAMETERS".

### DIFF
--- a/lib/Mojolicious/Plugin/FormFields.pm
+++ b/lib/Mojolicious/Plugin/FormFields.pm
@@ -42,6 +42,10 @@ sub register
 	  }
       }
 
+      my $hash = Mojolicious::Plugin::ParamExpand::expander
+        ->expand_hash($c->req->params->to_hash);
+      $c->param($_ => $hash->{$_}) for keys %$hash;
+
       $c->stash->{"$ns.errors"} = $errors;
       $valid;
   });
@@ -271,7 +275,8 @@ sub valid
     }
 
     $result = Validate::Tiny::validate($field, $rules);
-    $self->{c}->param($name, $result->{data}->{$name}) if @{$self->{filters}};
+    $self->{c}->req->params->param($name, $result->{data}->{$name})
+        if @{$self->{filters}};
     $self->{result} = $result;
 
     $result->{success};

--- a/t/filters.t
+++ b/t/filters.t
@@ -38,6 +38,24 @@ post '/scoped_multiple_filters' => sub {
     $c->render(text => $c->param('user.name'));
 };
 
+post '/structured_request_parameters_with_scoped_single_filter' => sub {
+    my $c = shift;
+    my $user = $c->fields('user');
+    $user->filter(name => 'uc');
+    $c->valid;
+    my $params = $c->param('user');
+    $c->render(text => $params->{'name'});
+};
+
+post '/structured_request_parameters_with_scoped_multiple_filters' => sub {
+    my $c = shift;
+    my $user = $c->fields('user');
+    $user->filter('name', 'uc', 'strip')->filter('trim');
+    $c->valid;
+    my $params = $c->param('user');
+    $c->render(text => $params->{'name'});
+};
+
 post '/custom_filter' => sub {
     my $c = shift;
     $c->field('name')->filter(sub { chop $_[0]; $_[0] });
@@ -64,6 +82,12 @@ $t->post_ok('/multiple_filters',
             form => { 'name' => ' a   b     c   ' })->status_is(200)->content_is('A B C');
 
 $t->post_ok('/scoped_multiple_filters',
+            form => { 'user.name' => ' a   b     c   ' })->status_is(200)->content_is('A B C');
+
+$t->post_ok('/structured_request_parameters_with_scoped_single_filter',
+            form => { 'user.name' => 'fofinha' })->status_is(200)->content_is('FOFINHA');
+
+$t->post_ok('/structured_request_parameters_with_scoped_multiple_filters',
             form => { 'user.name' => ' a   b     c   ' })->status_is(200)->content_is('A B C');
 
 $t->post_ok('/custom_filter',


### PR DESCRIPTION
The parameters in this method can be obtained, but the filter is not applied.Is this would specification?


```
my $fields = $c->fields('user');
$fields->filter('name', 'uc', 'strip')->filter('trim');
$c->valid;

# not ok
my $user = $c->param('user');
$user->{name};

# ok
$c->param('user.name');
```


This pull request might inefficient. Since reason to repeat the code to be executed by "Mojolicious :: Plugin :: ParamExpand".